### PR TITLE
Fix compilation on OS X.

### DIFF
--- a/kobuki_gazebo_plugins/CMakeLists.txt
+++ b/kobuki_gazebo_plugins/CMakeLists.txt
@@ -1,11 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(kobuki_gazebo_plugins)
 
-# Find gazebo
-include (FindPkgConfig)
-if (PKG_CONFIG_FOUND)
-  pkg_check_modules(GAZEBO gazebo)
-endif()
+find_package(gazebo REQUIRED)
 
 find_package(catkin REQUIRED COMPONENTS gazebo_ros
                                         geometry_msgs
@@ -38,7 +34,9 @@ add_dependencies(gazebo_ros_kobuki geometry_msgs_gencpp
                                    nav_msgs_gencpp
                                    sensor_msgs_gencpp
                                    std_msgs_gencpp)
-target_link_libraries(gazebo_ros_kobuki ${catkin_LIBRARIES})
+target_link_libraries(gazebo_ros_kobuki
+                      ${catkin_LIBRARIES}
+                      ${GAZEBO_LIBRARIES})
 
 install(TARGETS gazebo_ros_kobuki
         DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})


### PR DESCRIPTION
- without this linking fails on OS X (10.9)
  - not sure if directly referencing protobuf is the right thing here, or if
    gazebo's pkg-config should export the protobuf flags?
