### PR TITLE
kobuki_gazebo_plugins: Resolve IMU sensor using fully scoped name

### DIFF
--- a/kobuki_gazebo_plugins/src/gazebo_ros_kobuki_loads.cpp
+++ b/kobuki_gazebo_plugins/src/gazebo_ros_kobuki_loads.cpp
@@ -295,7 +295,7 @@ bool GazeboRosKobuki::prepareIMU()
     return false;
   }
   imu_ = boost::dynamic_pointer_cast<sensors::ImuSensor>(
-            sensors::SensorManager::Instance()->GetSensor(imu_name));
+            sensors::get_sensor(world_->GetName()+"::"+node_name_+"::base_footprint::"+imu_name));
   if (!imu_)
   {
     ROS_ERROR_STREAM("Couldn't find the IMU in the model! [" << node_name_ <<"]");


### PR DESCRIPTION
This ensures uniqueness among multiple models in which the sensor has the
same name. In this case, our specific motivation is the Kobuki Gazebo
plugin being spawned multiple times using kobuki_gazebo.urdf.xacro in the
package kobuki_description.

This is intended to fix issue #38
