### PR TITLE
fix the wrong behavior with a kobuki model on Gazebo5.

### DIFF
--- a/kobuki_gazebo_plugins/src/gazebo_ros_kobuki_updates.cpp
+++ b/kobuki_gazebo_plugins/src/gazebo_ros_kobuki_updates.cpp
@@ -178,8 +178,6 @@ void GazeboRosKobuki::propagateVelocityCommands()
   }
   joints_[LEFT]->SetVelocity(0, wheel_speed_cmd_[LEFT] / (wheel_diam_ / 2.0));
   joints_[RIGHT]->SetVelocity(0, wheel_speed_cmd_[RIGHT] / (wheel_diam_ / 2.0));
-  joints_[LEFT]->SetMaxForce(0, torque_);
-  joints_[RIGHT]->SetMaxForce(0, torque_);
 }
 
 /*


### PR DESCRIPTION
https://github.com/yujinrobot/kobuki_desktop/issues/41 I modified to not use SetMaxForce method.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/yujinrobot/kobuki_desktop/42)

<!-- Reviewable:end -->
