### PR TITLE
use &quot; for nested double quote

### DIFF
--- a/kobuki_gazebo/launch/includes/robot.launch.xml
+++ b/kobuki_gazebo/launch/includes/robot.launch.xml
@@ -4,7 +4,7 @@
 <launch>
   <arg name="robot_name" value="mobile_base"/>
   <param name="robot_description"
-        command="$(find xacro)/xacro --inorder '$(find kobuki_description)/urdf/kobuki_standalone.urdf.xacro'"/>
+        command="$(find xacro)/xacro --inorder &quot;$(find kobuki_description)/urdf/kobuki_standalone.urdf.xacro&quot;"/>
   <node pkg="gazebo_ros" type="spawn_model" name="spawn_$(arg robot_name)"
         args="-x 0.0 -y 0.0 -z 1.5 -unpause -urdf -param robot_description -model $(arg robot_name)" respawn="false">
   </node>


### PR DESCRIPTION
using `'` (single quote) leads to the following error message on Windows:
```
>roslaunch kobuki_gazebo kobuki_empty_world.launch --screen
... logging to C:\Users\kejxu\.ros\log\fd82fbee-9a03-11e9-a567-480fcf49b453\roslaunch-kejxu-z240-882276.log
Checking log directory for disk usage. This may take a while.
Press Ctrl-C to interrupt
Done checking log file disk usage. Usage is <1GB.
[93mxacro: in-order processing became default in ROS Melodic. You can drop the option.[0m
[91minvalid mode ('r') or filename: 'C:\ros\catkin_ws\turtlebot2\install_isolated\share\kobuki_description\urdf\kobuki_standalone.urdf.xacro'[0m
[31mRLException: while processing C:\ros\catkin_ws\turtlebot2\install_isolated\share\kobuki_gazebo\launch\includes\robot.launch.xml:
Invalid <param> tag: Cannot load command parameter [robot_description]: command [C:/opt/ros/melodic/x64\lib\xacro\xacro.exe --inorder 'C:\ros\catkin_ws\turtlebot2\install_isolated\share\kobuki_description\urdf\kobuki_standalone.urdf.xacro'] returned with code [2].

Param xml is <param command="$(find xacro)/xacro --inorder '$(find kobuki_description)/urdf/kobuki_standalone.urdf.xacro'" name="robot_description"/>[0m
[31mThe traceback for the exception was written to the log file[0m
```

single quotation marks do not work well on Windows. for example, the following would not work:
```batch
cd 'nested_dir'
```
and this works:
```batch
cd "nested_dir"
```

suggesting to change to use `&quot;`

reference:
https://stackoverflow.com/questions/22468479/are-nested-double-quotes-incorrect-in-xml