### PR TITLE
Call propagateVelocityCommands() at the full simulation rate unconditionally

### DIFF
--- a/kobuki_gazebo_plugins/src/gazebo_ros_kobuki.cpp
+++ b/kobuki_gazebo_plugins/src/gazebo_ros_kobuki.cpp
@@ -116,13 +116,16 @@ void GazeboRosKobuki::OnUpdate()
   #endif
 
   if (time_now < prev_update_time_) {
-      ROS_WARN_NAMED("gazebo_ros_kobuki", "Negative update time difference detected.");
-      prev_update_time_ = time_now;
+    ROS_WARN_NAMED("gazebo_ros_kobuki", "Negative update time difference detected.");
+    prev_update_time_ = time_now;
   }
 
   common::Time step_time = time_now - prev_update_time_;
 
-  // rate control
+  // propagate wheel velocity commands at the full simulation rate
+  propagateVelocityCommands();
+
+  // publish rate control
   if (this->update_rate_ > 0 && step_time.Double() < (1.0 / this->update_rate_)) {
     return;
   }
@@ -132,7 +135,6 @@ void GazeboRosKobuki::OnUpdate()
   updateJointState();
   updateOdometry(step_time);
   updateIMU();
-  propagateVelocityCommands();
   updateCliffSensor();
   updateBumper();
 }

--- a/kobuki_gazebo_plugins/src/gazebo_ros_kobuki_updates.cpp
+++ b/kobuki_gazebo_plugins/src/gazebo_ros_kobuki_updates.cpp
@@ -222,7 +222,13 @@ void GazeboRosKobuki::updateIMU()
  */
 void GazeboRosKobuki::propagateVelocityCommands()
 {
-  if (((prev_update_time_- last_cmd_vel_time_).Double() > cmd_vel_timeout_) || !motors_enabled_)
+  common::Time time_now;
+  #if GAZEBO_MAJOR_VERSION >= 9
+    time_now = world_->SimTime();
+  #else
+    time_now = world_->GetSimTime();
+  #endif
+  if (((time_now - last_cmd_vel_time_).Double() > cmd_vel_timeout_) || !motors_enabled_)
   {
     wheel_speed_cmd_[LEFT] = 0.0;
     wheel_speed_cmd_[RIGHT] = 0.0;


### PR DESCRIPTION
This PR fixes a bug introduced in #61. It addresses the problem described  by @cobot [here](https://github.com/yujinrobot/kobuki_desktop/commit/29f106799f8426cfe1c207d12b0e01f27d25feb2#commitcomment-42286682):
> Hi, sorry, I was not particularly clear. I try to explain better with videos. I use a finer simulation than that from [kobuki_gazebo/playground.world](https://github.com/yujinrobot/kobuki_desktop/blob/melodic/kobuki_gazebo/worlds/playground.world):
> 
> ```
>     <physics type="ode">
>       <max_step_size>0.001</max_step_size>
>       <real_time_factor>1</real_time_factor>
>       <real_time_update_rate>1000</real_time_update_rate>
>      ...
> ```
> 
> With this configuration, this is the default simulated behavior when spinning, without setting update_rate:
> 
> https://drive.google.com/file/d/1d7GYWod4_EAuk7q3NrzC_c_6DZ1Ft8By/view?usp=sharing
> 
> But setting it to 20 Hz I get:
> 
> https://drive.google.com/file/d/1T2ffTqze-EGvEItMplCb6JW-fnwzSAO0/view?usp=sharing
> 
> Looks like the robot cannot achieve the commanded velocity (6.6 rad/sec).
> 
> With the default simulation settings, robot spin faster, but still slower than commanded:
> 
> https://drive.google.com/file/d/15-lDS23H3EVi5Wj22oN_OAw86UDA67Ia/view?usp=sharing
> 
> But linear speed is fine, so I suppose the reason is that we skip 49 out of 50 update steps (1000 / 20 = 50). For the odometry calculation this doesn't matter, as we use step_time as time delta, but the IMU is not scaled accordingly. [Here](https://github.com/corot/kobuki_desktop/tree/publish_rate) I made a fast change implementing the change I propose: throttle only the tf and topics publishing, not the plugins updates. Can u give it a try (note that I set bigger real_time_update_rate to 1000)?


following the approach proposed [here](https://github.com/yujinrobot/kobuki_desktop/commit/1b2009bd9a0c80ed128d090a0c8304f1594ebefb#r42736406).

**Assumption:**

`Joint::SetVelocity()` must be called in each simulation update step, or otherwise Gazebo will either reset it to zero for the next time step, or simulated friction and other physical effects reduce the joint velocity until the next `SetVelocity()` command, because Gazebo assumes that no torque is applied.