### PR TITLE
Added wheel drop sensors event publishers

### DIFF
--- a/kobuki_gazebo_plugins/include/kobuki_gazebo_plugins/gazebo_ros_kobuki.h
+++ b/kobuki_gazebo_plugins/include/kobuki_gazebo_plugins/gazebo_ros_kobuki.h
@@ -112,7 +112,7 @@ private:
   bool prepareVelocityCommand();
   bool prepareCliffSensor();
   bool prepareBumper();
-  bool prepareWheelDropSensors();
+  bool prepareWheelDrop();
   bool prepareIMU();
   void setupRosApi(std::string& model_name);
 
@@ -223,7 +223,7 @@ private:
   sensors::ContactSensorPtr bumper_;
   /// ROS publisher for bumper events
   ros::Publisher bumper_event_pub_;
-  /// Kobuki ROS message for bumper event
+  /// Kobuki ROS message for bumper events
   kobuki_msgs::BumperEvent bumper_event_;
   /// Flag for left bumper's last state
   bool bumper_left_was_pressed_;
@@ -238,15 +238,15 @@ private:
   /// Flag for left bumper's current state
   bool bumper_right_is_pressed_;
   /// Pointers to wheel contact sensors used to simulate Kobuki's wheel drop sensors
-  sensors::ContactSensorPtr wheel_left_drop_;
-  sensors::ContactSensorPtr wheel_right_drop_;
+  sensors::ContactSensorPtr wheel_drop_left_;
+  sensors::ContactSensorPtr wheel_drop_right_;
   /// ROS publisher for wheel drop events
   ros::Publisher wheel_drop_main_pub_;
-  /// Kobuki ROS message for wheel drop event
-  kobuki_msgs::WheelDropEvent wheel_drop_main_event_;
+  /// Kobuki ROS message for wheel drop events
+  kobuki_msgs::WheelDropEvent wheel_drop_event_;
   /// Wheel drop sensor flags
-  bool wheel_left_raised_flag_ = false, wheel_left_lowered_flag_ = false;
-  bool wheel_right_raised_flag_ = false, wheel_right_lowered_flag_ = false;
+  bool wheel_left_dropped_flag_ = false;
+  bool wheel_right_dropped_flag_ = false;
   /// Pointer to IMU sensor model
   sensors::ImuSensorPtr imu_;
   /// Storage for the angular velocity reported by the IMU

--- a/kobuki_gazebo_plugins/include/kobuki_gazebo_plugins/gazebo_ros_kobuki.h
+++ b/kobuki_gazebo_plugins/include/kobuki_gazebo_plugins/gazebo_ros_kobuki.h
@@ -68,6 +68,7 @@
 #include <kobuki_msgs/MotorPower.h>
 #include <kobuki_msgs/CliffEvent.h>
 #include <kobuki_msgs/BumperEvent.h>
+#include <kobuki_msgs/WheelDropEvent.h>
 #include <kobuki_msgs/SensorState.h>
 
 namespace gazebo
@@ -111,6 +112,7 @@ private:
   bool prepareVelocityCommand();
   bool prepareCliffSensor();
   bool prepareBumper();
+  bool prepareWheelDropSensors();
   bool prepareIMU();
   void setupRosApi(std::string& model_name);
 
@@ -121,6 +123,7 @@ private:
   void propagateVelocityCommands();
   void updateCliffSensor();
   void updateBumper();
+  void updateWheelDrop();
   void pubSensorState();
 
   /*
@@ -234,6 +237,16 @@ private:
   bool bumper_center_is_pressed_;
   /// Flag for left bumper's current state
   bool bumper_right_is_pressed_;
+  /// Pointers to wheel contact sensors used to simulate Kobuki's wheel drop sensors
+  sensors::ContactSensorPtr wheel_left_drop_;
+  sensors::ContactSensorPtr wheel_right_drop_;
+  /// ROS publisher for wheel drop events
+  ros::Publisher wheel_drop_main_pub_;
+  /// Kobuki ROS message for wheel drop event
+  kobuki_msgs::WheelDropEvent wheel_drop_main_event_;
+  /// Wheel drop sensor flags
+  bool wheel_left_raised_flag_ = false, wheel_left_lowered_flag_ = false;
+  bool wheel_right_raised_flag_ = false, wheel_right_lowered_flag_ = false;
   /// Pointer to IMU sensor model
   sensors::ImuSensorPtr imu_;
   /// Storage for the angular velocity reported by the IMU

--- a/kobuki_gazebo_plugins/src/gazebo_ros_kobuki.cpp
+++ b/kobuki_gazebo_plugins/src/gazebo_ros_kobuki.cpp
@@ -81,6 +81,8 @@ void GazeboRosKobuki::Load(physics::ModelPtr parent, sdf::ElementPtr sdf)
     return;
   if(prepareBumper() == false)
     return;
+  if(prepareWheelDropSensors() == false)
+    return;
   if(prepareIMU() == false)
     return;
 
@@ -137,6 +139,7 @@ void GazeboRosKobuki::OnUpdate()
   updateIMU();
   updateCliffSensor();
   updateBumper();
+  updateWheelDrop();
   pubSensorState();
 }
 

--- a/kobuki_gazebo_plugins/src/gazebo_ros_kobuki.cpp
+++ b/kobuki_gazebo_plugins/src/gazebo_ros_kobuki.cpp
@@ -81,7 +81,7 @@ void GazeboRosKobuki::Load(physics::ModelPtr parent, sdf::ElementPtr sdf)
     return;
   if(prepareBumper() == false)
     return;
-  if(prepareWheelDropSensors() == false)
+  if(prepareWheelDrop() == false)
     return;
   if(prepareIMU() == false)
     return;

--- a/kobuki_gazebo_plugins/src/gazebo_ros_kobuki_loads.cpp
+++ b/kobuki_gazebo_plugins/src/gazebo_ros_kobuki_loads.cpp
@@ -283,6 +283,40 @@ bool GazeboRosKobuki::prepareBumper()
 }
 
 /*
+ * Prepare main wheel drop sensors
+ */
+bool GazeboRosKobuki::prepareWheelDropSensors()
+{
+  std::string wheel_left_name;
+  std::string wheel_right_name;
+
+  if (sdf_->HasElement("wheel_left_sensor_name") && sdf_->HasElement("wheel_right_sensor_name"))
+  {
+    wheel_left_name = sdf_->GetElement("wheel_left_sensor_name")->Get<std::string>();
+    wheel_right_name = sdf_->GetElement("wheel_right_sensor_name")->Get<std::string>();
+  }
+  else
+  {
+    ROS_ERROR_STREAM("Couldn't find the name of one of the wheel drop sensors in the model description!"
+                     << " Did you specify it?" << " [" << node_name_ <<"]");
+    return false;
+  }
+  wheel_left_drop_ = std::dynamic_pointer_cast<sensors::ContactSensor>(
+            sensors::SensorManager::Instance()->GetSensor(wheel_left_name));
+  wheel_right_drop_ = std::dynamic_pointer_cast<sensors::ContactSensor>(
+            sensors::SensorManager::Instance()->GetSensor(wheel_right_name));
+  if (!wheel_left_drop_ || !wheel_right_drop_)
+  {
+    ROS_ERROR_STREAM("Couldn't find one of the wheel drop sensors in the model! [" << node_name_ <<"]");
+    return false;
+  }
+
+  wheel_left_drop_->SetActive(true);
+  wheel_right_drop_->SetActive(true);
+  return true;
+}
+
+/*
  * Prepare IMU
  */
 bool GazeboRosKobuki::prepareIMU()
@@ -358,6 +392,11 @@ void GazeboRosKobuki::setupRosApi(std::string& model_name)
   std::string bumper_topic = base_prefix + "/events/bumper";
   bumper_event_pub_ = gazebo_ros_->node()->advertise<kobuki_msgs::BumperEvent>(bumper_topic, 1);
   ROS_INFO("%s: Advertise Bumper[%s]!", gazebo_ros_->info(), bumper_topic.c_str());
+
+  // wheel_drop_main
+  std::string wheel_drop_main_topic = base_prefix + "/events/wheel_drop";
+  wheel_drop_main_pub_ = gazebo_ros_->node()->advertise<kobuki_msgs::WheelDropEvent>(wheel_drop_main_topic, 1);
+  ROS_INFO("%s: Advertise Wheel Drop[%s]!", gazebo_ros_->info(), wheel_drop_main_topic.c_str());
 
   // IMU
   std::string imu_topic = base_prefix + "/sensors/imu_data";

--- a/kobuki_gazebo_plugins/src/gazebo_ros_kobuki_loads.cpp
+++ b/kobuki_gazebo_plugins/src/gazebo_ros_kobuki_loads.cpp
@@ -285,15 +285,15 @@ bool GazeboRosKobuki::prepareBumper()
 /*
  * Prepare main wheel drop sensors
  */
-bool GazeboRosKobuki::prepareWheelDropSensors()
+bool GazeboRosKobuki::prepareWheelDrop()
 {
   std::string wheel_left_name;
   std::string wheel_right_name;
 
-  if (sdf_->HasElement("wheel_left_sensor_name") && sdf_->HasElement("wheel_right_sensor_name"))
+  if (sdf_->HasElement("wheel_drop_left_sensor_name") && sdf_->HasElement("wheel_drop_right_sensor_name"))
   {
-    wheel_left_name = sdf_->GetElement("wheel_left_sensor_name")->Get<std::string>();
-    wheel_right_name = sdf_->GetElement("wheel_right_sensor_name")->Get<std::string>();
+    wheel_left_name = sdf_->GetElement("wheel_drop_left_sensor_name")->Get<std::string>();
+    wheel_right_name = sdf_->GetElement("wheel_drop_right_sensor_name")->Get<std::string>();
   }
   else
   {
@@ -301,18 +301,18 @@ bool GazeboRosKobuki::prepareWheelDropSensors()
                      << " Did you specify it?" << " [" << node_name_ <<"]");
     return false;
   }
-  wheel_left_drop_ = std::dynamic_pointer_cast<sensors::ContactSensor>(
+  wheel_drop_left_ = std::dynamic_pointer_cast<sensors::ContactSensor>(
             sensors::SensorManager::Instance()->GetSensor(wheel_left_name));
-  wheel_right_drop_ = std::dynamic_pointer_cast<sensors::ContactSensor>(
+  wheel_drop_right_ = std::dynamic_pointer_cast<sensors::ContactSensor>(
             sensors::SensorManager::Instance()->GetSensor(wheel_right_name));
-  if (!wheel_left_drop_ || !wheel_right_drop_)
+  if (!wheel_drop_left_ || !wheel_drop_right_)
   {
     ROS_ERROR_STREAM("Couldn't find one of the wheel drop sensors in the model! [" << node_name_ <<"]");
     return false;
   }
 
-  wheel_left_drop_->SetActive(true);
-  wheel_right_drop_->SetActive(true);
+  wheel_drop_left_->SetActive(true);
+  wheel_drop_right_->SetActive(true);
   return true;
 }
 
@@ -393,7 +393,7 @@ void GazeboRosKobuki::setupRosApi(std::string& model_name)
   bumper_event_pub_ = gazebo_ros_->node()->advertise<kobuki_msgs::BumperEvent>(bumper_topic, 1);
   ROS_INFO("%s: Advertise Bumper[%s]!", gazebo_ros_->info(), bumper_topic.c_str());
 
-  // wheel_drop_main
+  // wheel drop sensors
   std::string wheel_drop_main_topic = base_prefix + "/events/wheel_drop";
   wheel_drop_main_pub_ = gazebo_ros_->node()->advertise<kobuki_msgs::WheelDropEvent>(wheel_drop_main_topic, 1);
   ROS_INFO("%s: Advertise Wheel Drop[%s]!", gazebo_ros_->info(), wheel_drop_main_topic.c_str());

--- a/kobuki_gazebo_plugins/src/gazebo_ros_kobuki_updates.cpp
+++ b/kobuki_gazebo_plugins/src/gazebo_ros_kobuki_updates.cpp
@@ -462,8 +462,9 @@ void GazeboRosKobuki::updateWheelDrop()
 
 /**
  * Core sensor state: msg concentrating all the low-level information reported by Kobuki base.
- * We provide only bumper and cliff sensors so we can integrate their readings on the costmaps
- * with the https://github.com/yujinrobot/kobuki/tree/melodic/kobuki_bumper2pc nodelet.
+ * We provide only bumper and cliff sensors (so we can integrate their readings on the costmaps
+ * with the https://github.com/yujinrobot/kobuki/tree/melodic/kobuki_bumper2pc nodelet) and
+ * wheel-drop sensors (mostly for completeness).
  */
 void GazeboRosKobuki::pubSensorState()
 {
@@ -483,6 +484,11 @@ void GazeboRosKobuki::pubSensorState()
     state.cliff |= kobuki_msgs::SensorState::CLIFF_CENTRE;
   if (cliff_detected_right_)
     state.cliff |= kobuki_msgs::SensorState::CLIFF_RIGHT;
+
+  if (wheel_left_dropped_flag_)
+    state.wheel_drop |= kobuki_msgs::SensorState::WHEEL_DROP_LEFT;
+  if (wheel_right_dropped_flag_)
+    state.wheel_drop |= kobuki_msgs::SensorState::WHEEL_DROP_RIGHT;
 
   sensor_state_pub_.publish(state);
 }

--- a/kobuki_gazebo_plugins/src/gazebo_ros_kobuki_updates.cpp
+++ b/kobuki_gazebo_plugins/src/gazebo_ros_kobuki_updates.cpp
@@ -416,6 +416,55 @@ void GazeboRosKobuki::updateBumper()
   }
 }
 
+/*
+ * Main wheel drop sensors
+ */
+/// Contacts between the wheels and the base are not reported by Gazebo.
+/// This means that ANY contacts that the wheels have are either with the main surface or with a colliding object.
+/// This functions ignores the second case
+void GazeboRosKobuki::updateWheelDrop()
+{
+    msgs::Contacts contacts_left = wheel_left_drop_->Contacts();
+    msgs::Contacts contacts_right = wheel_right_drop_->Contacts();
+
+
+    ///Left wheel drop sensor
+    if (contacts_left.contact_size() > 0 && !wheel_left_raised_flag_)
+    {
+        wheel_drop_main_event_.wheel = kobuki_msgs::WheelDropEvent::LEFT;
+        wheel_drop_main_event_.state = kobuki_msgs::WheelDropEvent::RAISED;
+        wheel_drop_main_pub_.publish(wheel_drop_main_event_);
+        wheel_left_raised_flag_ = true;
+        wheel_left_lowered_flag_ = false;
+    }
+    else if (contacts_left.contact_size() == 0 && !wheel_left_lowered_flag_)
+    {
+        wheel_drop_main_event_.wheel = kobuki_msgs::WheelDropEvent::LEFT;
+        wheel_drop_main_event_.state = kobuki_msgs::WheelDropEvent::DROPPED;
+        wheel_drop_main_pub_.publish(wheel_drop_main_event_);
+        wheel_left_lowered_flag_ = true;
+        wheel_left_raised_flag_ = false;
+    }
+
+    ///Right wheel drop sensor
+    if (contacts_right.contact_size() > 0 && !wheel_right_raised_flag_)
+    {
+        wheel_drop_main_event_.wheel = kobuki_msgs::WheelDropEvent::RIGHT;
+        wheel_drop_main_event_.state = kobuki_msgs::WheelDropEvent::RAISED;
+        wheel_drop_main_pub_.publish(wheel_drop_main_event_);
+        wheel_right_raised_flag_ = true;
+        wheel_right_lowered_flag_ = false;
+    }
+    else if (contacts_right.contact_size() == 0 && !wheel_right_lowered_flag_)
+    {
+        wheel_drop_main_event_.wheel = kobuki_msgs::WheelDropEvent::RIGHT;
+        wheel_drop_main_event_.state = kobuki_msgs::WheelDropEvent::DROPPED;
+        wheel_drop_main_pub_.publish(wheel_drop_main_event_);
+        wheel_right_lowered_flag_ = true;
+        wheel_right_raised_flag_ = false;
+    }
+}
+
 /**
  * Core sensor state: msg concentrating all the low-level information reported by Kobuki base.
  * We provide only bumper and cliff sensors so we can integrate their readings on the costmaps
@@ -442,4 +491,5 @@ void GazeboRosKobuki::pubSensorState()
 
   sensor_state_pub_.publish(state);
 }
-}
+
+} // gazebo namespace

--- a/kobuki_gazebo_plugins/src/gazebo_ros_kobuki_updates.cpp
+++ b/kobuki_gazebo_plugins/src/gazebo_ros_kobuki_updates.cpp
@@ -417,52 +417,47 @@ void GazeboRosKobuki::updateBumper()
 }
 
 /*
- * Main wheel drop sensors
+ * Wheel drop sensors
+ * Contacts between the wheels and the base are not reported by Gazebo.
+ * This means that ANY contacts that the wheels have are either with the main surface or with a colliding object.
+ * This functions ignores the second case
  */
-/// Contacts between the wheels and the base are not reported by Gazebo.
-/// This means that ANY contacts that the wheels have are either with the main surface or with a colliding object.
-/// This functions ignores the second case
 void GazeboRosKobuki::updateWheelDrop()
 {
-    msgs::Contacts contacts_left = wheel_left_drop_->Contacts();
-    msgs::Contacts contacts_right = wheel_right_drop_->Contacts();
+  msgs::Contacts contacts_left = wheel_drop_left_->Contacts();
+  msgs::Contacts contacts_right = wheel_drop_right_->Contacts();
 
+  /// Left wheel drop sensor
+  if (contacts_left.contact_size() > 0 && wheel_left_dropped_flag_)
+  {
+    wheel_drop_event_.wheel = kobuki_msgs::WheelDropEvent::LEFT;
+    wheel_drop_event_.state = kobuki_msgs::WheelDropEvent::RAISED;
+    wheel_drop_main_pub_.publish(wheel_drop_event_);
+    wheel_left_dropped_flag_ = false;
+  }
+  else if (contacts_left.contact_size() == 0 && !wheel_left_dropped_flag_)
+  {
+    wheel_drop_event_.wheel = kobuki_msgs::WheelDropEvent::LEFT;
+    wheel_drop_event_.state = kobuki_msgs::WheelDropEvent::DROPPED;
+    wheel_drop_main_pub_.publish(wheel_drop_event_);
+    wheel_left_dropped_flag_ = true;
+  }
 
-    ///Left wheel drop sensor
-    if (contacts_left.contact_size() > 0 && !wheel_left_raised_flag_)
-    {
-        wheel_drop_main_event_.wheel = kobuki_msgs::WheelDropEvent::LEFT;
-        wheel_drop_main_event_.state = kobuki_msgs::WheelDropEvent::RAISED;
-        wheel_drop_main_pub_.publish(wheel_drop_main_event_);
-        wheel_left_raised_flag_ = true;
-        wheel_left_lowered_flag_ = false;
-    }
-    else if (contacts_left.contact_size() == 0 && !wheel_left_lowered_flag_)
-    {
-        wheel_drop_main_event_.wheel = kobuki_msgs::WheelDropEvent::LEFT;
-        wheel_drop_main_event_.state = kobuki_msgs::WheelDropEvent::DROPPED;
-        wheel_drop_main_pub_.publish(wheel_drop_main_event_);
-        wheel_left_lowered_flag_ = true;
-        wheel_left_raised_flag_ = false;
-    }
-
-    ///Right wheel drop sensor
-    if (contacts_right.contact_size() > 0 && !wheel_right_raised_flag_)
-    {
-        wheel_drop_main_event_.wheel = kobuki_msgs::WheelDropEvent::RIGHT;
-        wheel_drop_main_event_.state = kobuki_msgs::WheelDropEvent::RAISED;
-        wheel_drop_main_pub_.publish(wheel_drop_main_event_);
-        wheel_right_raised_flag_ = true;
-        wheel_right_lowered_flag_ = false;
-    }
-    else if (contacts_right.contact_size() == 0 && !wheel_right_lowered_flag_)
-    {
-        wheel_drop_main_event_.wheel = kobuki_msgs::WheelDropEvent::RIGHT;
-        wheel_drop_main_event_.state = kobuki_msgs::WheelDropEvent::DROPPED;
-        wheel_drop_main_pub_.publish(wheel_drop_main_event_);
-        wheel_right_lowered_flag_ = true;
-        wheel_right_raised_flag_ = false;
-    }
+  /// Right wheel drop sensor
+  if (contacts_right.contact_size() > 0 && wheel_right_dropped_flag_)
+  {
+    wheel_drop_event_.wheel = kobuki_msgs::WheelDropEvent::RIGHT;
+    wheel_drop_event_.state = kobuki_msgs::WheelDropEvent::RAISED;
+    wheel_drop_main_pub_.publish(wheel_drop_event_);
+    wheel_right_dropped_flag_ = false;
+  }
+  else if (contacts_right.contact_size() == 0 && !wheel_right_dropped_flag_)
+  {
+    wheel_drop_event_.wheel = kobuki_msgs::WheelDropEvent::RIGHT;
+    wheel_drop_event_.state = kobuki_msgs::WheelDropEvent::DROPPED;
+    wheel_drop_main_pub_.publish(wheel_drop_event_);
+    wheel_right_dropped_flag_ = true;
+  }
 }
 
 /**


### PR DESCRIPTION
The wheels contact sensors do not register contacts with the base of the robot. Therefore, it is assumed that any contact made is with the floor.

Requires https://github.com/yujinrobot/kobuki/pull/425 to be merged.

Addresses https://github.com/yujinrobot/kobuki_desktop/issues/62