### PR TITLE
Invert contact normal only if the robot is the first colliding object

### DIFF
--- a/kobuki_gazebo_plugins/src/gazebo_ros_kobuki_updates.cpp
+++ b/kobuki_gazebo_plugins/src/gazebo_ros_kobuki_updates.cpp
@@ -344,14 +344,16 @@ void GazeboRosKobuki::updateBumper()
     #else
       rel_contact_pos =  contacts.contact(i).position(0).z() - current_pose.pos.z;
     #endif
-    // Actually, only contacts at the height of the bumper should be considered, but since we use a simplified collision model
-    // contacts further below and above need to be consider as well to identify "bumps" reliably.
-    if ((rel_contact_pos >= 0.01)
-        && (rel_contact_pos <= 0.13))
+    // Actually, only contacts at the height of the bumper should be considered, but since we use a simplified
+    // collision model contacts further below and above need to be consider as well to identify "bumps" reliably.
+    if (rel_contact_pos >= 0.01 && rel_contact_pos <= 0.13)
     {
+      // contact normal goes from second to first colliding model, so we need to invert if the robot is the first
+      double normal_sign = contacts.contact(i).collision1().find(bumper_->ParentName()) == 0 ? -1.0 : +1.0;
       // using the force normals below, since the contact position is given in world coordinates
       // also negating the normal, because it points from contact to robot centre
-      double global_contact_angle = std::atan2(-contacts.contact(i).normal(0).y(), -contacts.contact(i).normal(0).x());
+      double global_contact_angle = std::atan2(normal_sign * contacts.contact(i).normal(0).y(),
+                                               normal_sign * contacts.contact(i).normal(0).x());
       double relative_contact_angle = global_contact_angle - robot_heading;
 
       if ((relative_contact_angle <= (M_PI/2)) && (relative_contact_angle > (M_PI/6)))


### PR DESCRIPTION
Contact normal goes from second to first colliding model, so we need to invert it only if the robot is the first
This is most of the times the case (that's why it mostly work), but not always, e.g.
```
Collision between[lack_table_11::link::collision] and [thorp::base_footprint::base_footprint_fixed_joint_lump__base_collision]
0  Position:9.05951 2.63089 0.0163409
   Normal:-0.991845 -0.127448 -0
   robot_heading:-2.95965
   global_contact_angle:-3.0138
   relative_contact_angle:-0.0541515
   0   1   0
1  Position:9.05951 2.63089 0.0166435
   Normal:-0.991845 -0.127448 0
   robot_heading:-2.95965
   global_contact_angle:-3.0138
   relative_contact_angle:-0.0541515
   0   1   0
2  Position:9.0595 2.63089 0.0153666
   Normal:-0.991845 -0.127448 0
   robot_heading:-2.95965
   global_contact_angle:-3.0138
   relative_contact_angle:-0.0541515
   0   1   0
```
![image](https://user-images.githubusercontent.com/322610/110453213-4824eb80-8109-11eb-9bc6-93132da1311b.png)

But here robot comes first:
```
Collision between[thorp::base_footprint::base_footprint_fixed_joint_lump__base_collision] and [turtlebot3_house::Wall_93::Wall_93_Collision]
0  Position:12.225 3.41991 0.0160865
   Normal:-1 3.67321e-06 -0
   robot_heading:0.0589247
   global_contact_angle:-3.67321e-06
   relative_contact_angle:-0.0589284
   0   1   0
1  Position:12.225 3.41991 0.0160865
   Normal:-1 3.67321e-06 -0
   robot_heading:0.0589247
   global_contact_angle:-3.67321e-06
   relative_contact_angle:-0.0589284
   0   1   0
```
![image](https://user-images.githubusercontent.com/322610/110453576-a05bed80-8109-11eb-812e-21d47ed3d613.png)
