### PR TITLE
Removed duplications of the odom tf publication

### DIFF
--- a/kobuki_gazebo_plugins/include/kobuki_gazebo_plugins/gazebo_ros_kobuki.h
+++ b/kobuki_gazebo_plugins/include/kobuki_gazebo_plugins/gazebo_ros_kobuki.h
@@ -197,6 +197,8 @@ private:
   bool publish_tf_;
   /// TF transform publisher for the odom frame
   tf::TransformBroadcaster tf_broadcaster_;
+  /// The time of the most recent published state
+  ros::Time last_published_tf_stamp_;
   /// TF transform for the odom frame
   geometry_msgs::TransformStamped odom_tf_;
   /// Pointer to left cliff sensor

--- a/kobuki_gazebo_plugins/src/gazebo_ros_kobuki_updates.cpp
+++ b/kobuki_gazebo_plugins/src/gazebo_ros_kobuki_updates.cpp
@@ -147,7 +147,8 @@ void GazeboRosKobuki::updateOdometry(common::Time& step_time)
   odom_.twist.twist.angular.z = odom_vel_[2];
   odom_pub_.publish(odom_); // publish odom message
 
-  if (publish_tf_)
+  // As of ROS Noetic, TF2 will issue warnings whenever we try to publish with the same time stamp.
+  if (publish_tf_ && odom_.header.stamp > last_published_tf_stamp_)
   {
     odom_tf_.header = odom_.header;
     odom_tf_.child_frame_id = odom_.child_frame_id;
@@ -157,6 +158,9 @@ void GazeboRosKobuki::updateOdometry(common::Time& step_time)
     odom_tf_.transform.rotation = odom_.pose.pose.orientation;
     tf_broadcaster_.sendTransform(odom_tf_);
   }
+
+  // Retain the last published stamp for detecting repeatedtransforms in future cycles
+  last_published_tf_stamp_ = odom_.header.stamp;
 }
 
 /*


### PR DESCRIPTION
This PR is for removing warnings of the duplicated tf like [cra-ros-pkg/robot_localization#595](https://github.com/cra-ros-pkg/robot_localization/pull/595).

By this PR, the program will publish the odom tf only when the timestamp is new.